### PR TITLE
Fix bug: Language driver id isn't saved in database.

### DIFF
--- a/xBaseJ/src/org/xBaseJ/DBF.java
+++ b/xBaseJ/src/org/xBaseJ/DBF.java
@@ -618,6 +618,7 @@ public class DBF implements Closeable {
 
 			tempDBF = new DBF(newName, format, true);
 			tempDBF.version =   format;
+			tempDBF.language = language;
 			tempDBF.MDX_exist = MDX_exist;
 
 		}


### PR DESCRIPTION
When set language id for new database, final database is still have language with predefined value 0x03.
